### PR TITLE
feat: Add an Ipv6 CIDR context construct

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'github-actions[bot]')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
     steps:
       - uses: hmarr/auto-approve-action@v2.1.0
         with:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.1.0",
+      "version": "2.12.0",
       "type": "build"
     },
     {
@@ -107,7 +107,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.1.0",
+      "version": "^2.12.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -28,12 +28,15 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
 
   stability: "experimental",
-  cdkVersion: "2.1.0",
+  cdkVersion: "2.12.0",
   majorVersion: 0,
   prerelease: "alpha",
 
   projenTokenSecret: "GITHUB_TOKEN",
-  autoApproveOptions: {},
+  autoApproveOptions: {
+    // Anyone with write access to this repository can have auto-approval.
+    allowedUsernames: [],
+  },
   depsUpgradeOptions: {
     workflowOptions: {
       labels: ["auto-approve"],

--- a/API.md
+++ b/API.md
@@ -1,39 +1,182 @@
 # API Reference <a name="API Reference" id="api-reference"></a>
 
+## Constructs <a name="Constructs" id="constructs"></a>
 
+### CidrContext <a name="shady-island.CidrContext" id="shadyislandcidrcontext"></a>
 
-## Classes <a name="Classes" id="classes"></a>
+- *Implements:* [`shady-island.ICidrContext`](#shady-island.ICidrContext)
 
-### Hello <a name="shady-island.Hello" id="shadyislandhello"></a>
+Allocates IPv6 CIDRs and routes for subnets in a VPC.
 
-#### Initializers <a name="shady-island.Hello.Initializer" id="shadyislandhelloinitializer"></a>
+> {@link https://github.com/aws/aws-cdk/issues/5927}
+
+#### Initializers <a name="shady-island.CidrContext.Initializer" id="shadyislandcidrcontextinitializer"></a>
 
 ```typescript
-import { Hello } from 'shady-island'
+import { CidrContext } from 'shady-island'
 
-new Hello()
+new CidrContext(scope: Construct, id: string, options: CidrContextProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| [`scope`](#shadyislandcidrcontextparameterscope)<span title="Required">*</span> | [`constructs.Construct`](#constructs.Construct) | The construct scope. |
+| [`id`](#shadyislandcidrcontextparameterid)<span title="Required">*</span> | `string` | The construct ID. |
+| [`options`](#shadyislandcidrcontextparameteroptions)<span title="Required">*</span> | [`shady-island.CidrContextProps`](#shady-island.CidrContextProps) | The constructor options. |
 
 ---
 
-#### Methods <a name="Methods" id="methods"></a>
+##### `scope`<sup>Required</sup> <a name="shady-island.CidrContext.parameter.scope" id="shadyislandcidrcontextparameterscope"></a>
 
-| **Name** | **Description** |
-| --- | --- |
-| [`sayHello`](#shadyislandhellosayhello) | *No description.* |
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+The construct scope.
 
 ---
 
-##### `sayHello` <a name="shady-island.Hello.sayHello" id="shadyislandhellosayhello"></a>
+##### `id`<sup>Required</sup> <a name="shady-island.CidrContext.parameter.id" id="shadyislandcidrcontextparameterid"></a>
+
+- *Type:* `string`
+
+The construct ID.
+
+---
+
+##### `options`<sup>Required</sup> <a name="shady-island.CidrContext.parameter.options" id="shadyislandcidrcontextparameteroptions"></a>
+
+- *Type:* [`shady-island.CidrContextProps`](#shady-island.CidrContextProps)
+
+The constructor options.
+
+---
+
+
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`vpc`](#shadyislandcidrcontextpropertyvpc)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc) | The IPv6-enabled VPC. |
+
+---
+
+##### `vpc`<sup>Required</sup> <a name="shady-island.CidrContext.property.vpc" id="shadyislandcidrcontextpropertyvpc"></a>
 
 ```typescript
-public sayHello()
+public readonly vpc: IVpc;
 ```
 
+- *Type:* [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc)
+
+The IPv6-enabled VPC.
+
+---
 
 
+## Structs <a name="Structs" id="structs"></a>
 
+### CidrContextProps <a name="shady-island.CidrContextProps" id="shadyislandcidrcontextprops"></a>
+
+Properties for creating a new {@link CidrContext}.
+
+#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
+
+```typescript
+import { CidrContextProps } from 'shady-island'
+
+const cidrContextProps: CidrContextProps = { ... }
+```
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`vpc`](#shadyislandcidrcontextpropspropertyvpc)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc) | The VPC whose subnets will be configured. |
+| [`addressPool`](#shadyislandcidrcontextpropspropertyaddresspool) | `string` | The ID of a BYOIP IPv6 address pool from which to allocate the CIDR block. |
+| [`cidrBlock`](#shadyislandcidrcontextpropspropertycidrblock) | `string` | An IPv6 CIDR block from the IPv6 address pool to use for this VPC. |
+| [`cidrCount`](#shadyislandcidrcontextpropspropertycidrcount) | `number` | Split the CIDRs into this many groups (by default one for each subnet). |
+
+---
+
+##### `vpc`<sup>Required</sup> <a name="shady-island.CidrContextProps.property.vpc" id="shadyislandcidrcontextpropspropertyvpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc)
+
+The VPC whose subnets will be configured.
+
+---
+
+##### `addressPool`<sup>Optional</sup> <a name="shady-island.CidrContextProps.property.addressPool" id="shadyislandcidrcontextpropspropertyaddresspool"></a>
+
+```typescript
+public readonly addressPool: string;
+```
+
+- *Type:* `string`
+
+The ID of a BYOIP IPv6 address pool from which to allocate the CIDR block.
+
+If this parameter is not specified or is undefined, the CIDR block will be provided by AWS.
+
+---
+
+##### `cidrBlock`<sup>Optional</sup> <a name="shady-island.CidrContextProps.property.cidrBlock" id="shadyislandcidrcontextpropspropertycidrblock"></a>
+
+```typescript
+public readonly cidrBlock: string;
+```
+
+- *Type:* `string`
+
+An IPv6 CIDR block from the IPv6 address pool to use for this VPC.
+
+The {@link EnableIpv6Props#addressPool} attribute is required if this parameter is specified.
+
+---
+
+##### `cidrCount`<sup>Optional</sup> <a name="shady-island.CidrContextProps.property.cidrCount" id="shadyislandcidrcontextpropspropertycidrcount"></a>
+
+```typescript
+public readonly cidrCount: number;
+```
+
+- *Type:* `number`
+
+Split the CIDRs into this many groups (by default one for each subnet).
+
+---
+
+
+## Protocols <a name="Protocols" id="protocols"></a>
+
+### ICidrContext <a name="shady-island.ICidrContext" id="shadyislandicidrcontext"></a>
+
+- *Implemented By:* [`shady-island.CidrContext`](#shady-island.CidrContext), [`shady-island.ICidrContext`](#shady-island.ICidrContext)
+
+Interface for the CidrContext class.
+
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`vpc`](#shadyislandicidrcontextpropertyvpc)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc) | The IPv6-enabled VPC. |
+
+---
+
+##### `vpc`<sup>Required</sup> <a name="shady-island.ICidrContext.property.vpc" id="shadyislandicidrcontextpropertyvpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc)
+
+The IPv6-enabled VPC.
+
+---
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.1.0",
+    "aws-cdk-lib": "2.12.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.3.0",
@@ -63,7 +63,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.12.0",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,1 @@
-export class Hello {
-  public sayHello(): string {
-    return "hello, world!";
-  }
-}
+export * from "./vpc";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Asserts that a value is an instance of a given type.
+ *
+ * @param value The value to test.
+ * @param type The type of which value must be an instance.
+ */
+export function assertType<T>(value: any, type: new (...args: any) => T): T {
+  if (value instanceof type) {
+    return value as T;
+  }
+  throw new TypeError(
+    `Expected value of type: ${type} but got ${typeof value}`
+  );
+}
+
+/**
+ * Locates an instance of a given type within an array.
+ *
+ * @param container The array to search.
+ * @param type The type of which value must be an instance.
+ * @return The located value
+ * @throws {TypeError} if the value was not found or not of
+ */
+export function findInstanceOf<A, T extends A>(
+  container: A[],
+  type: new (...args: any) => T
+) {
+  const value = container.find((v) => v instanceof type);
+  if (value !== undefined) {
+    return value as T;
+  }
+  throw new TypeError(`Array does not contain a value of type: ${type}`);
+}

--- a/src/vpc/cidr-context.ts
+++ b/src/vpc/cidr-context.ts
@@ -1,0 +1,176 @@
+import { Fn, CfnResource } from "aws-cdk-lib";
+import {
+  IVpc,
+  Vpc,
+  CfnEgressOnlyInternetGateway,
+  CfnVPCCidrBlock,
+  CfnInternetGateway,
+  CfnSubnet,
+  RouterType,
+  Subnet,
+} from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+
+import { assertType, findInstanceOf } from "../util";
+
+/**
+ * Properties for creating a new {@link CidrContext}.
+ */
+export interface CidrContextProps {
+  /**
+   * The VPC whose subnets will be configured.
+   */
+  readonly vpc: IVpc;
+  /**
+   * Split the CIDRs into this many groups (by default one for each subnet).
+   */
+  readonly cidrCount?: number;
+  /**
+   * The ID of a BYOIP IPv6 address pool from which to allocate the CIDR block.
+   *
+   * If this parameter is not specified or is undefined, the CIDR block will be
+   * provided by AWS.
+   */
+  readonly addressPool?: string;
+  /**
+   * An IPv6 CIDR block from the IPv6 address pool to use for this VPC.
+   *
+   * The {@link EnableIpv6Props#addressPool} attribute is required if this
+   * parameter is specified.
+   */
+  readonly cidrBlock?: string;
+}
+
+/**
+ * Interface for the CidrContext class.
+ */
+export interface ICidrContext {
+  /**
+   * The IPv6-enabled VPC.
+   */
+  readonly vpc: IVpc;
+}
+
+/**
+ * Allocates IPv6 CIDRs and routes for subnets in a VPC.
+ *
+ * @see {@link https://github.com/aws/aws-cdk/issues/894}
+ * @see {@link https://github.com/aws/aws-cdk/issues/5927}
+ */
+export class CidrContext extends Construct implements ICidrContext {
+  public readonly vpc: IVpc;
+
+  /**
+   * Creates a new BetterVpc.
+   *
+   * @param scope - The construct scope.
+   * @param id - The construct ID.
+   * @param options - The constructor options.
+   */
+  constructor(scope: Construct, id: string, options: CidrContextProps) {
+    super(scope, id);
+
+    const vpc = assertType(options.vpc, Vpc);
+    this.vpc = vpc;
+
+    // Create the Egress-only Internet Gateway for the private subnets.
+    const egressOnlyInternetGateway =
+      vpc.privateSubnets.length > 0
+        ? new CfnEgressOnlyInternetGateway(this, "EgressOnlyIgw", {
+            vpcId: vpc.vpcId,
+          })
+        : undefined;
+
+    // Locate the Internet Gateway.
+    const internetGateway = findInstanceOf(
+      vpc.node.children,
+      CfnInternetGateway
+    );
+
+    // Create the VPC CIDR block.
+    const cidrBlock = new CfnVPCCidrBlock(this, "Ipv6CidrBlock", {
+      vpcId: vpc.vpcId,
+      amazonProvidedIpv6CidrBlock: options.addressPool !== undefined,
+      ipv6Pool: options.addressPool,
+      ipv6CidrBlock: options.cidrBlock,
+    });
+    // Figure out the minimun required CIDR subnets and the number desired.
+    const leastCidrBlocksNeeded =
+      vpc.publicSubnets.length +
+      vpc.privateSubnets.length +
+      vpc.isolatedSubnets.length;
+    const cidrBlockCount = options?.cidrCount ?? leastCidrBlocksNeeded;
+    if (cidrBlockCount < leastCidrBlocksNeeded) {
+      throw new Error(
+        `You must create at least ${leastCidrBlocksNeeded} CIDR blocks in this VPC`
+      );
+    }
+
+    // Create a placeholder for CloudFormation to provide a CIDR array.
+    const cidrs = Fn.cidr(
+      Fn.select(0, vpc.vpcIpv6CidrBlocks),
+      cidrBlockCount,
+      "64"
+    );
+
+    this.assignSubnetCidrs(
+      vpc,
+      cidrs,
+      cidrBlock,
+      internetGateway,
+      egressOnlyInternetGateway
+    );
+  }
+
+  private assignSubnetCidrs(
+    vpc: Vpc,
+    cidrs: string[],
+    cidrBlock: CfnResource,
+    internetGateway: CfnInternetGateway,
+    egressOnlyInternetGateway?: CfnEgressOnlyInternetGateway
+  ): void {
+    for (const [index, subnet] of vpc.publicSubnets.entries()) {
+      // Add a Route to the Internet gateway for Internet-bound IPv6 traffic.
+      const concreteSubnet = assertType(subnet, Subnet);
+      concreteSubnet.addRoute("DefaultIpv6Route", {
+        routerId: internetGateway.ref,
+        routerType: RouterType.GATEWAY,
+        destinationIpv6CidrBlock: "::/0",
+      });
+      // Define the IPv6 CIDR block for this subnet.
+      const cfnSubnet = assertType(concreteSubnet.node.defaultChild, CfnSubnet);
+      cfnSubnet.ipv6CidrBlock = Fn.select(index, cidrs);
+      cfnSubnet.addDependsOn(cidrBlock);
+      // TODO: create a custom resource that will set the auto-assign IPv6.
+    }
+
+    for (const [index, subnet] of vpc.privateSubnets.entries()) {
+      // Add a Route to the Egress-only Internet Gateway.
+      const concreteSubnet = assertType(subnet, Subnet);
+      concreteSubnet.addRoute("DefaultIpv6Route", {
+        routerId: `${egressOnlyInternetGateway?.ref}`,
+        routerType: RouterType.EGRESS_ONLY_INTERNET_GATEWAY,
+        destinationIpv6CidrBlock: "::/0",
+      });
+      // Define the IPv6 CIDR block for this subnet.
+      const cfnSubnet = assertType(concreteSubnet.node.defaultChild, CfnSubnet);
+      cfnSubnet.ipv6CidrBlock = Fn.select(
+        index + vpc.publicSubnets.length,
+        cidrs
+      );
+      cfnSubnet.addDependsOn(cidrBlock);
+      // TODO: create a custom resource that will set the auto-assign IPv6.
+    }
+
+    for (const [index, subnet] of vpc.isolatedSubnets.entries()) {
+      // Define the IPv6 CIDR block for this subnet.
+      const cfnSubnet = assertType(subnet.node.defaultChild, CfnSubnet);
+      cfnSubnet.ipv6CidrBlock = Fn.select(
+        index + vpc.publicSubnets.length + vpc.privateSubnets.length,
+        cidrs
+      );
+      cfnSubnet.addDependsOn(cidrBlock);
+      // TODO: create a custom resource that will set the auto-assign IPv6.
+    }
+  }
+}

--- a/src/vpc/cidr-context.ts
+++ b/src/vpc/cidr-context.ts
@@ -90,7 +90,7 @@ export class CidrContext extends Construct implements ICidrContext {
     // Create the VPC CIDR block.
     const cidrBlock = new CfnVPCCidrBlock(this, "Ipv6CidrBlock", {
       vpcId: vpc.vpcId,
-      amazonProvidedIpv6CidrBlock: options.addressPool !== undefined,
+      amazonProvidedIpv6CidrBlock: options.addressPool === undefined,
       ipv6Pool: options.addressPool,
       ipv6CidrBlock: options.cidrBlock,
     });

--- a/src/vpc/index.ts
+++ b/src/vpc/index.ts
@@ -1,0 +1,1 @@
+export * from "./cidr-context";

--- a/test/hello.test.ts
+++ b/test/hello.test.ts
@@ -1,5 +1,0 @@
-import { Hello } from "../src";
-
-test("hello", () => {
-  expect(new Hello().sayHello()).toBe("hello, world!");
-});

--- a/test/vpc/cidr-context.test.ts
+++ b/test/vpc/cidr-context.test.ts
@@ -1,0 +1,30 @@
+import * as cdk from "aws-cdk-lib";
+import { /* Capture, Match, */ Template } from "aws-cdk-lib/assertions";
+import { Vpc } from "aws-cdk-lib/aws-ec2";
+import { CidrContext } from "../../src/vpc";
+
+describe("CidrContext", () => {
+  test("synthesizes the way we expect", () => {
+    const app = new cdk.App();
+
+    const myStack = new cdk.Stack(app, "TopicsStack");
+
+    const vpc = new Vpc(myStack, "Vpc", {});
+    /* const cidrContext =*/ new CidrContext(myStack, "CidrContext", {
+      vpc: vpc,
+    });
+
+    const template = Template.fromStack(myStack);
+
+    // Assert it creates the function with the correct properties...
+    // template.hasResourceProperties("AWS::Lambda::Function", {
+    //   Handler: "handler",
+    //   Runtime: "nodejs14.x",
+    // });
+
+    // Creates the subscription...
+    template.resourceCountIs("AWS::EC2::VPC", 1);
+    template.resourceCountIs("AWS::EC2::EgressOnlyInternetGateway", 1);
+    template.resourceCountIs("AWS::EC2::VPCCidrBlock", 1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,17 +1129,17 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.1.0.tgz#2497484cfd4e2eeaba99b070bbfa54486d52ae34"
-  integrity sha512-W607G3aSrWpawpcqzIuUYKlU+grfvkbszyqikyVYqJgMHFCCQXq0S1ynPMzfQ49CwjlwZsu4LIsPM+dNR+Yj6g==
+aws-cdk-lib@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.12.0.tgz#377e71b5d1ba549fbc5c1baf01bd2d7320ad1df4"
+  integrity sha512-ot2gJycvHy9OqKkiDVSOP1QNOxapNUbjahEWSp0Mdxkweark0OdrzBv4JNaJYfGMn8IdZZ6FV/hpsi4MYHQ/+w==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.1.9"
+    ignore "^5.2.0"
     jsonschema "^1.4.0"
-    minimatch "^3.0.4"
+    minimatch "^3.0.5"
     punycode "^2.1.1"
     semver "^7.3.5"
     yaml "1.10.2"
@@ -2863,7 +2863,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0:
+ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -4160,7 +4160,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
   integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==


### PR DESCRIPTION
This is the addition of a new construct (the first actual construct) which creates an IPv6 context for a VPC.