### PR TITLE
fix(rds): allow RDS Serverless v1 enough time to wake from idle

### DIFF
--- a/src/rds/triggers/mysql.handler.ts
+++ b/src/rds/triggers/mysql.handler.ts
@@ -49,6 +49,7 @@ const handler = async () => {
     password: adminSecret.password,
     port: adminSecret.port,
     ssl: "Amazon RDS",
+    connectTimeout: 40000,
   });
 
   let createDbSql = `CREATE DATABASE IF NOT EXISTS ${databaseName} CHARACTER SET ${characterSet}`;


### PR DESCRIPTION
The Trigger fails with the default connect timeout of 10 seconds when an RDS Serverless v1 database is sleeping. This sucks because it's a VPC function because it takes 15 minutes to tear down.